### PR TITLE
Floating IP sync improvements

### DIFF
--- a/internal/fipcontroller/fipcontroller.go
+++ b/internal/fipcontroller/fipcontroller.go
@@ -126,7 +126,8 @@ func (fc *Controller) syncFloatingIPs() (bool, error) {
 
 			fc.fips[ip] = fip
 			changedFIPs = true
-		} else if oldFIP.Server.Name != fc.attachments[ip] {
+		} else if (oldFIP.Server != nil && oldFIP.Server.Name != fc.attachments[ip]) || (oldFIP.Server == nil && fc.attachments[ip] != "") {
+			// FIP hasn't changed but attachment doesn't match so let's reconcile
 			changedFIPs = true
 		}
 	}

--- a/internal/fipcontroller/fipcontroller.go
+++ b/internal/fipcontroller/fipcontroller.go
@@ -110,7 +110,7 @@ func (fc *Controller) syncFloatingIPs() (bool, error) {
 		seenFIPs.Add(ip)
 		oldFIP := fc.fips[ip]
 
-		if fc.fipChanged(oldFIP, fip) {
+		if oldFIP == nil || fc.fipChanged(oldFIP, fip) {
 			// resolve Server reference (API returns only empty struct with ID)
 			// TODO: can we safely cache server info? Can we even support name changes?
 			if fip.Server != nil {
@@ -126,7 +126,7 @@ func (fc *Controller) syncFloatingIPs() (bool, error) {
 
 			fc.fips[ip] = fip
 			changedFIPs = true
-		} else if oldFIP != nil && oldFIP.Server.Name != fc.attachments[ip] {
+		} else if oldFIP.Server.Name != fc.attachments[ip] {
 			changedFIPs = true
 		}
 	}
@@ -198,7 +198,7 @@ func (fc *Controller) Reconcile() {
 }
 
 func (fc *Controller) fipChanged(oldFIP *hcloud.FloatingIP, newFIP *hcloud.FloatingIP) bool {
-	if oldFIP != newFIP || oldFIP.ID != newFIP.ID {
+	if oldFIP.ID != newFIP.ID {
 		return true
 	}
 


### PR DESCRIPTION
During my tests I have encountered issue where the controller would send IP assignment requests to Hetzner API even though the floating IP was already attached to the correct server. This would occur every 5 minutes.

I don't know if this has any other negative side-effects but at the very least it's a couple of redundant API calls and notifications in Hetzner Cloud Console (every floating IP assignement API call creates new notification there, no matter if this actually changed anything or not).

After some investigation it turned out the culprit was `syncFloatingIPs` function which didn't update old FIP's in the `fips` map. The map was only updated when FIP ID's changed but not when Server ID's changed. Since the map wasn't updated the `Reconcile` function would then do the floating IP assignment API call - and continue to do it every 5 minutes.

This PR fixes this bug by modifying the `syncFloatingIPs` to take into the account Server ID's as well. There are also changes that should reduce amount of redundant reconciles caused by that function. 

I'm always open to suggestions if you don't like some changes in this PR. :)