### PR TITLE
Better integration with MetalLB L2 speaker and possible service conflict fix

### DIFF
--- a/internal/servicecontroller/servicecontroller.go
+++ b/internal/servicecontroller/servicecontroller.go
@@ -164,6 +164,7 @@ func (sc *Controller) addPodInformer(svc *corev1.Service) error {
 	podInformerFactory := informers.NewSharedInformerFactoryWithOptions(
 		sc.K8S,
 		time.Duration(config.Global.SyncSeconds)*time.Second,
+		informers.WithNamespace(svc.Namespace),
 		informers.WithTweakListOptions(func(listOpts *metav1.ListOptions) {
 			listOpts.LabelSelector = labels.Set(svc.Spec.Selector).String()
 		}),

--- a/internal/servicecontroller/servicecontroller.go
+++ b/internal/servicecontroller/servicecontroller.go
@@ -1,7 +1,10 @@
 package servicecontroller
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 


### PR DESCRIPTION
Currently picking the node for floating IP assignment seems to rely on K8s sorting pods in some kind of deterministic way. Putting aside whether that's actually deterministic or not (I didn't have time to verify this), it doesn't match with what MetalLB is doing. MetalLB L2 speaker sorts all of the nodes with ready pods (actually it uses endpoints but that's story for another day) by their SHA256 hash of `nodename#namespace/service` and then picks the first one (https://github.com/metallb/metallb/blob/a9a6f3195a008c7094a17f11c025899177699c79/speaker/layer2_controller.go#L83).

MetalLB in L2 mode only does ARP announcements on the node it selects. So when the IP Floater controller happens to pick a different node than MetalLB, things just won't work unless you handle ARP in some other way - for example by adding all floating IPs to nodes interfaces yourself.

This PR adds sorting of nodes to match MetalLB's.
Additionaly there's a fix for a service conflict which could happen when two different services from two different namespaces had the same name.