### PR TITLE
Fix race condition that can lead to a deadlock

### DIFF
--- a/internal/fipcontroller/fipcontroller.go
+++ b/internal/fipcontroller/fipcontroller.go
@@ -55,7 +55,6 @@ func (fc *Controller) Run() {
 // AttachToNode adds a FIP-to-node attachment to our worldview and immediately attempts to reconcile it with hcloud's
 func (fc *Controller) AttachToNode(svcIPs stringset.StringSet, node string) {
 	fc.attMu.Lock()
-	defer fc.attMu.Unlock()
 
 	var changedAttachment bool
 	for ip := range svcIPs {
@@ -64,6 +63,8 @@ func (fc *Controller) AttachToNode(svcIPs stringset.StringSet, node string) {
 			changedAttachment = true
 		}
 	}
+
+	fc.attMu.Unlock()
 
 	if changedAttachment {
 		_, err := fc.syncFloatingIPs()


### PR DESCRIPTION
There's a possible race condition that can lead to a deadlock which completely stops reconcilation process.
It can happen when reconcilation process enters loop (locks `fipsMu` and then `attMu` each iteration) and service controller executes AttachToNode function which locks `attMu` and then locks `fipsMu` inside `syncLoopingIPs`.

This PR changes deferred unlock to direct unlock call right after stopping iteration over attachments map.

Fixes #10 