### PR TITLE
Use stable RBAC kinds

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: hcloud-ip-floater
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: hcloud-ip-floater
@@ -20,7 +20,7 @@ rules:
   resources: ["pods"]
   verbs: ["get","watch","list"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: hcloud-ip-floater


### PR DESCRIPTION
The beta manifest kinds have been deprecated since 1.17, it should be fine to switch now.